### PR TITLE
Add libsnappy

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -75,6 +75,17 @@
               "sha256": "e8ff01e6cc38d1b3fd56a083f5860737dbd2f319a39037528fb1a74a89ae9878"
             }
           ]
+        },
+        {
+          "name": "libsnappy",
+          "buildsystem": "cmake",
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://github.com/google/snappy/archive/1.1.7.tar.gz",
+              "sha256": "3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
While cmake is in there, it's not installing libsnappy.so. Need more investigation.