### PR TITLE
filesystem: Make host the default

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -13,7 +13,7 @@
     "--share=ipc",
     "--share=network",
     "--device=all",
-    "--filesystem=home",
+    "--filesystem=host",
     "--allow=multiarch"
   ],
   "modules": [


### PR DESCRIPTION
This makes it so that `host` is the default filesystem access, allowing access to all files.

Fixes #31