### PR TITLE
Compile with DBus support and enable talk to the ScreenSaver service

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -14,12 +14,16 @@
     "--share=network",
     "--device=all",
     "--filesystem=host",
-    "--allow=multiarch"
+    "--allow=multiarch",
+    "--talk-name=org.freedesktop.ScreenSaver"
   ],
   "modules": [
     "shared-modules/udev/udev-175.json",
     {
       "name": "retroarch",
+      "config-opts": [
+        "--enable-dbus"
+      ],
       "make-args": [
         "GLOBAL_CONFIG_DIR=/app/etc"
       ],


### PR DESCRIPTION
This immediately fixes #58 under X, and after commit https://github.com/libretro/RetroArch/commit/65232d3ab479a6051a7742c5a8f19b7a291f0199 ends up in a release this also fixes #58 under Wayland.