### PR TITLE
Enable WIMP Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ To test the application locally, use [flatpak-builder](http://docs.flatpak.org/e
 git clone --recursive https://github.com/flathub/org.libretro.RetroArch.git
 cd org.libretro.RetroArch
 flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-flatpak install --user flathub org.freedesktop.Sdk//1.6
-flatpak install --user flathub org.freedesktop.Platform//1.6
+flatpak install --user flathub org.kde.Sdk//5.9
+flatpak install --user flathub org.kde.Platform//5.9
 flatpak-builder --repo=libretro --force-clean retroarch org.libretro.RetroArch.json
 flatpak remote-add --user libretro libretro --no-gpg-verify
 flatpak install --user libretro org.libretro.RetroArch

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -1,8 +1,8 @@
 {
   "app-id": "org.libretro.RetroArch",
-  "runtime": "org.freedesktop.Platform",
-  "runtime-version": "1.6",
-  "sdk": "org.freedesktop.Sdk",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.9",
+  "sdk": "org.kde.Sdk",
   "command": "retroarch",
   "rename-desktop-file": "retroarch.desktop",
   "rename-icon": "retroarch",


### PR DESCRIPTION
The KDE SDK comes with Qt, which enables the WIMP interface.

Fixes #56