### PR TITLE
Unhardcode installation paths

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -53,7 +53,7 @@
         "mv ${FLATPAK_DEST}/share/pixmaps/retroarch.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/",
         "rmdir ${FLATPAK_DEST}/share/pixmaps/",
         "mkdir -p ${FLATPAK_DEST}/etc",
-        "cp retroarch.cfg ${FLATPAK_DEST}/etc",
+        "sed s:@prefix@:${FLATPAK_DEST}:g retroarch.cfg > ${FLATPAK_DEST}/etc/retroarch.cfg",
         "mkdir -p ${FLATPAK_DEST}/share/appdata",
         "cp org.libretro.RetroArch.appdata.xml ${FLATPAK_DEST}/share/appdata"
       ],

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -30,7 +30,7 @@
         "--enable-dbus"
       ],
       "make-args": [
-        "GLOBAL_CONFIG_DIR=/app/etc"
+        "GLOBAL_CONFIG_DIR=${FLATPAK_DEST}/etc"
       ],
       "sources": [
         {
@@ -49,13 +49,13 @@
         }
       ],
       "post-install": [
-        "mkdir -p /app/share/icons/hicolor/scalable/apps/",
-        "mv /app/share/pixmaps/retroarch.svg /app/share/icons/hicolor/scalable/apps/",
-        "rmdir /app/share/pixmaps/",
-        "mkdir -p /app/etc",
-        "cp retroarch.cfg /app/etc",
-        "mkdir -p /app/share/appdata",
-        "cp org.libretro.RetroArch.appdata.xml /app/share/appdata"
+        "mkdir -p ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/",
+        "mv ${FLATPAK_DEST}/share/pixmaps/retroarch.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/",
+        "rmdir ${FLATPAK_DEST}/share/pixmaps/",
+        "mkdir -p ${FLATPAK_DEST}/etc",
+        "cp retroarch.cfg ${FLATPAK_DEST}/etc",
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.libretro.RetroArch.appdata.xml ${FLATPAK_DEST}/share/appdata"
       ],
       "modules": [
         "libpng/libpng-1.2.59.json",
@@ -66,7 +66,7 @@
       "name": "retroarch-filers-video",
       "subdir": "gfx/video_filters",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -80,7 +80,7 @@
       "name": "retroarch-filers-audio",
       "subdir": "libretro-common/audio/dsp_filters",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -93,7 +93,7 @@
     {
       "name": "retroarch-assets",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -106,7 +106,7 @@
     {
       "name": "libretro-database",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -119,7 +119,7 @@
     {
       "name": "libretro-core-info",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -132,7 +132,7 @@
     {
       "name": "retroarch-joypad-autoconfig",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -145,7 +145,7 @@
     {
       "name": "common-shaders",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -158,7 +158,7 @@
     {
       "name": "slang-shaders",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -171,7 +171,7 @@
     {
       "name": "glsl-shaders",
       "make-install-args": [
-        "PREFIX=/app"
+        "PREFIX=${FLATPAK_DEST}"
       ],
       "sources": [
         {

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -1,18 +1,18 @@
 # Assets directory. This location is queried by default when menu interfaces try to look for
 # loadable assets, etc.
-assets_directory = "/app/share/libretro/assets/"
+assets_directory = "@prefix@/share/libretro/assets/"
 
 # Path to content database directory.
-content_database_path = "/app/share/libretro/database/rdb"
+content_database_path = "@prefix@/share/libretro/database/rdb"
 
 # Path to cheat database directory.
-cheat_database_path = "/app/share/libretro/database/cht"
+cheat_database_path = "@prefix@/share/libretro/database/cht"
 
 # Saved queries are stored to this directory.
-cursor_directory = "/app/share/libretro/database/cursors"
+cursor_directory = "@prefix@/share/libretro/database/cursors"
 
 # A directory for where to search for libretro core information.
-libretro_info_path = "/app/share/libretro/info"
+libretro_info_path = "@prefix@/share/libretro/info"
 
 # Directory for joypad autoconfigs.
 # If a joypad is plugged in, that joypad will be autoconfigured if a config file
@@ -20,7 +20,7 @@ libretro_info_path = "/app/share/libretro/info"
 # Input binds which are made explicit (input_playerN_*_btn/axis) will take priority over autoconfigs.
 # Autoconfigs can be created with retroarch-joyconfig, manually, or with a frontend.
 # Requires input_autodetect_enable to be enabled.
-joypad_autoconfig_dir = "/app/share/libretro/autoconfig"
+joypad_autoconfig_dir = "@prefix@/share/libretro/autoconfig"
 
 # Input driver. Depending on video driver, it might force a different input driver.
 input_driver = "x"
@@ -33,13 +33,13 @@ input_joypad_driver = "sdl2"
 suspend_screensaver_enable  = false
 
 # Defines a directory where CPU-based video filters are kept.
-video_filter_dir = "/app/lib/retroarch/filters/video"
+video_filter_dir = "@prefix@/lib/retroarch/filters/video"
 
 # Directory where DSP plugins are kept.
-audio_filter_dir = "/app/lib/retroarch/filters/audio"
+audio_filter_dir = "@prefix@/lib/retroarch/filters/audio"
 
 # Defines a directory where shaders (Cg, CGP, GLSL) are kept for easy access.
-video_shader_dir = "/app/share/libretro/shaders"
+video_shader_dir = "@prefix@/share/libretro/shaders"
 
 # If disabled, will hide 'Online Updater' inside the menu.
 menu_show_core_updater = "true"


### PR DESCRIPTION
Using `${FLATPAK_DEST}` instead of `/app` can help a lot for reusing the manifest for building RetroArch as an extension instead of a standalone app, e.g. for Lutris RobLoach/net.lutris.Lutris#37.