### PR TITLE
Disable cdrom support

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -27,7 +27,8 @@
     {
       "name": "retroarch",
       "config-opts": [
-        "--enable-dbus"
+        "--enable-dbus",
+        "--disable-cdrom"
       ],
       "make-args": [
         "GLOBAL_CONFIG_DIR=${FLATPAK_DEST}/etc"


### PR DESCRIPTION
Looks like flatpak is denying access to optimal media which results in a buffer overflow. Disable CDROM support for now.

Fixes #121