### PR TITLE
input_joypad_driver: Switch to udev

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -26,7 +26,7 @@ joypad_autoconfig_dir = "@prefix@/share/libretro/autoconfig"
 input_driver = "x"
 
 # Joypad driver. ("udev", "linuxraw", "paraport", "sdl2", "hid", "dinput")
-input_joypad_driver = "sdl2"
+input_joypad_driver = "udev"
 
 # Suspends the screensaver if set to true. Is a hint that does not necessarily have to be honored
 # by video driver.


### PR DESCRIPTION
While this disables the joypad support, it does fix the choppy input polls. udev is not currently fully supported in Flatpak, so we'll have to figure out a better solution going forwards.

Fixes libretro/RetroArch#10447