### PR TITLE
Switch to SDL2 Gamepad

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -26,7 +26,7 @@ joypad_autoconfig_dir = "@prefix@/share/libretro/autoconfig"
 input_driver = "x"
 
 # Joypad driver. ("udev", "linuxraw", "paraport", "sdl2", "hid", "dinput")
-input_joypad_driver = "udev"
+input_joypad_driver = "sdl2"
 
 # Suspends the screensaver if set to true. Is a hint that does not necessarily have to be honored
 # by video driver.


### PR DESCRIPTION
`udev` isn't working in Flatpak. Should we use SDL2 instead?