### PR TITLE
Add libbz2 to support Play! core

### DIFF
--- a/libbz2/libbz2-1.0.8.json
+++ b/libbz2/libbz2-1.0.8.json
@@ -1,0 +1,20 @@
+{
+  "name": "libbz2",
+  "no-autogen": true,
+  "make-args": [
+    "--f=Makefile-libbz2_so",
+    "PREFIX=${FLATPAK_DEST}"
+  ],
+  "no-make-install": true,
+  "post-install": [
+    "mv libbz2.so.1.0.8 ${FLATPAK_DEST}/lib/",
+    "ln -s ${FLATPAK_DEST}/lib/libbz2.so.1.0.8 ${FLATPAK_DEST}/lib/libbz2.so.1.0"
+  ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
+      "sha256": "ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
+    }
+  ]
+}

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -24,6 +24,7 @@
     "shared-modules/SDL/SDL_net-1.2.8.json",
     "shared-modules/SDL/SDL_ttf-2.0.11.json",
     "udev/systemd-udev.json",
+    "libbz2/libbz2-1.0.8.json",
     {
       "name": "xrandr",
       "sources": [


### PR DESCRIPTION
The Playstation 2 core, Play!, expects libbz2.so.1.0 to exist at runtime. This commit adds it.

Let me know if there are any concerns.