### PR TITLE
Update runtime to 5.15

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.libretro.RetroArch",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.14",
+  "runtime-version": "5.15",
   "sdk": "org.kde.Sdk",
   "command": "retroarch",
   "rename-desktop-file": "retroarch.desktop",


### PR DESCRIPTION
This is the only app in my system that's still on KDE 5.14.

WIMP GUI is working correctly as far as I can tell. **edit: though see the Wayland comment below.**

Something was off with the font settings/rendering on KDE 5.14 when using the Wayland backend (`QT_QPA_PLATFORM=wayland`). Now with KDE 5.15 there's no such issue and it looks exactly like X11 (`QT_QPA_PLATFORM=xcb`).  
Note that WIMP is not very stable with Wayland on my system, at least with Sway 1.5, and this true also for 5.14 so no change there.

Only briefly tested as I have only one game in my library.
