### PR TITLE
Add PCSX2 dependencies: libaio and libGLU

### DIFF
--- a/libaio/libaio-0.3.112.json
+++ b/libaio/libaio-0.3.112.json
@@ -1,0 +1,18 @@
+{
+  "name": "libaio",
+  "no-autogen": true,
+  "make-install-args": [
+    "prefix=${FLATPAK_DEST}"
+  ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://releases.pagure.org/libaio/libaio-0.3.112.tar.gz",
+      "sha256": "ab0462f2c9d546683e5147b1ce9c195fe95d07fac5bf362f6c01637955c3b492"
+    }
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/*.a"
+  ]
+}

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -66,7 +66,9 @@
         "shared-modules/libusb/libusb.json",
         "shared-modules/gudev/gudev.json",
         "libbz2/libbz2-1.0.8.json",
-        "xrandr/xrandr-1.5.1.json"
+        "xrandr/xrandr-1.5.1.json",
+        "libaio/libaio-0.3.112.json",
+        "shared-modules/glu/glu-9.json"
       ]
     },
     {


### PR DESCRIPTION
Fixes PCSX2 core on Flatpak, I've tested a few games, everything is working fine. I hope this can get in before releasing the Flatpak for 1.9.8, now that the blog has advertised PCSX2 big time, this version can't be taken seriously without it working too.