### PR TITLE
Update to v1.9.13.1

### DIFF
--- a/org.libretro.RetroArch.appdata.xml
+++ b/org.libretro.RetroArch.appdata.xml
@@ -51,7 +51,7 @@
           <li>NETPLAY: Networking - should not print country for a local lobby</li>
           <li>NETPLAY: Add Text Chat functionality</li>
           <li>OVERLAYS: Fix folder structure</li>
-          <li>VIDEO/ROTATION: Always return false if rotation can't occur. RETRO_ENVIRONMENT_SET_ROTATION should return false when rotation has been forcefully disabled in frontend, that way the core can decide if aspect ratio should be rotated or not for vertical games. Useful for FBNeo for instance.</li>
+          <li>VIDEO/ROTATION: Always return false if rotation can't occur</li>
           <li>FLATPAK: Add Overlays to the Flatpak distribution</li>
         </ul>
       </description>

--- a/org.libretro.RetroArch.appdata.xml
+++ b/org.libretro.RetroArch.appdata.xml
@@ -41,6 +41,21 @@
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="1.9.13.1" date="2021-11-10">
+      <url>https://www.libretro.com/index.php/retroarch-1-9-13-release/</url>
+      <description>
+        <ul>
+          <li>CHEEVOS: Fix need-to-activate achievement logic for non-hardcore</li>
+          <li>CHEEVOS: Don't queue rewind re-init if already on main thread</li>
+          <li>CHEEVOS: Ignore unofficial achievements unless setting is enabled</li>
+          <li>NETPLAY: Networking - should not print country for a local lobby</li>
+          <li>NETPLAY: Add Text Chat functionality</li>
+          <li>OVERLAYS: Fix folder structure</li>
+          <li>VIDEO/ROTATION: Always return false if rotation can't occur. RETRO_ENVIRONMENT_SET_ROTATION should return false when rotation has been forcefully disabled in frontend, that way the core can decide if aspect ratio should be rotated or not for vertical games. Useful for FBNeo for instance.</li>
+          <li>FLATPAK: Add Overlays to the Flatpak distribution</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.9.13" date="2021-11-07">
       <url>https://www.libretro.com/index.php/retroarch-1-9-13-release/</url>
       <description>

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -198,7 +198,7 @@
         {
           "type": "git",
           "url": "https://github.com/robloach/common-overlays.git",
-          "commit": "5a490f03f3e53aa1cb8b8dc2c9a09962beff6262"
+          "commit": "1face62381f807a811fc60d82ab7fc1bce73a319"
         }
       ]
     }

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -34,7 +34,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/RetroArch.git",
-          "branch": "a68b95690c315ab62676acf052dfbbb4bd156f83"
+          "branch": "1280151d13fd52d6c94f5592d27f5ba0b70dfd86"
         },
         {
           "type": "file",
@@ -80,7 +80,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/RetroArch.git",
-          "commit": "673d77284dfeb51bb1e48542ad6d062a08aec7e3"
+          "commit": "1280151d13fd52d6c94f5592d27f5ba0b70dfd86"
         }
       ]
     },
@@ -94,7 +94,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/RetroArch.git",
-          "commit": "673d77284dfeb51bb1e48542ad6d062a08aec7e3"
+          "commit": "1280151d13fd52d6c94f5592d27f5ba0b70dfd86"
         }
       ]
     },
@@ -186,6 +186,19 @@
           "type": "git",
           "url": "https://github.com/libretro/glsl-shaders.git",
           "commit": "3b66160795221bf73d51d63d6d86a93c0a0a21c7"
+        }
+      ]
+    },
+    {
+      "name": "common-overlays",
+      "make-install-args": [
+        "PREFIX=${FLATPAK_DEST}"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/robloach/common-overlays.git",
+          "commit": "5a490f03f3e53aa1cb8b8dc2c9a09962beff6262"
         }
       ]
     }

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -197,8 +197,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/robloach/common-overlays.git",
-          "commit": "1face62381f807a811fc60d82ab7fc1bce73a319"
+          "url": "https://github.com/libretro/common-overlays.git",
+          "commit": "db9744f4e58a740f0f10b04b62af347cd6f01928"
         }
       ]
     }

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -37,5 +37,8 @@ audio_filter_dir = "@prefix@/lib/retroarch/filters/audio"
 # Defines a directory where shaders (Cg, CGP, GLSL) are kept for easy access.
 video_shader_dir = "@prefix@/share/libretro/shaders"
 
+# Defines a directory where overlays are kept.
+overlay_directory = "@prefix@/share/libretro/overlays"
+
 # If disabled, will hide 'Online Updater' inside the menu.
 menu_show_core_updater = "true"


### PR DESCRIPTION
- ANDROID/PLAYSTORE: Implement MANAGE_EXTERNAL_STORAGE permission
- ANDROID/PLAYSTORE: Bump up SDK level to 30 to comply with Play Store policies
- CHEEVOS: Fix need-to-activate achievement logic for non-hardcore
- CHEEVOS: Don't queue rewind re-init if already on main thread
- CHEEVOS: Ignore unofficial achievements unless setting is enabled
- NETPLAY: Networking - should not print country for a local lobby
- NETPLAY: Add Text Chat functionality
- OVERLAYS: Revert changes
- VIDEO/ROTATION: Always return false if rotation can't occur.
- WIIU: Make wiiu_gfx_load_texture code safer
- FLATPAK: Add the Overlays to the distribution