### PR TITLE
Revert "Update runtime to 22.08"

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.libretro.RetroArch",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15-22.08",
+  "runtime-version": "5.15-21.08",
   "sdk": "org.kde.Sdk",
   "command": "retroarch",
   "rename-desktop-file": "retroarch.desktop",


### PR DESCRIPTION
Reverts flathub/org.libretro.RetroArch#227 ... Waiting until the official 22.08 announcement before making use of this.