### PR TITLE
Remove --filesystem=home as we already represent --filesystem=host

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -7,7 +7,7 @@
   "rename-desktop-file": "retroarch.desktop",
   "rename-icon": "retroarch",
   "finish-args": [
-    "--socket=x11",
+    "--socket=fallback-x11",
     "--socket=wayland",
     "--socket=pulseaudio",
     "--share=ipc",

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -14,7 +14,6 @@
     "--share=network",
     "--device=all",
     "--filesystem=host",
-    "--filesystem=home",
     "--allow=multiarch",
     "--talk-name=org.freedesktop.ScreenSaver",
     "--talk-name=org.freedesktop.PowerManagement.Inhibit",


### PR DESCRIPTION
This is related to the builder linter. The other issue is wayland support, which is covered over at https://github.com/flathub/flatpak-builder-lint/pull/19