### PR TITLE
Disable suspending the screensaver

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -46,3 +46,6 @@ menu_show_core_updater = "true"
 
 # Use WebM for video recording
 video_record_quality = "6"
+
+# Disable suspending the screensaver, as xdg-screensaver may not be available.
+suspend_screensaver_enable = "false"


### PR DESCRIPTION
RetroArch uses xdg-screensaver, which may not be available through flatpak.