### PR TITLE
Allow suspending the screensaver

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -46,6 +46,3 @@ menu_show_core_updater = "true"
 
 # Use WebM for video recording
 video_record_quality = "6"
-
-# Disable suspending the screensaver, as xdg-screensaver may not be available.
-suspend_screensaver_enable = "false"


### PR DESCRIPTION
Once RetroArch 1.17 is out, allow suspending the screensaver again, since it comes with the DBUS update.