### PR TITLE
retroarch: Default to the glcore video driver

### DIFF
--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -25,6 +25,9 @@ joypad_autoconfig_dir = "@prefix@/share/libretro/autoconfig"
 # Input driver. Depending on video driver, it might force a different input driver.
 input_driver = "x"
 
+# Video driver. Default to "glcore".
+video_driver = "glcore"
+
 # Joypad driver. ("udev", "linuxraw", "paraport", "sdl2", "hid", "dinput")
 # There are joypad permission issues with udev on Flatpak, so use SDL2 for now.
 input_joypad_driver = "sdl2"


### PR DESCRIPTION
This change makes the default video driver the `glcore` one, as the `gl` one has had some reports of failures.