### PR TITLE
Grant access to Gamescope socket

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -19,7 +19,8 @@
     "--talk-name=org.freedesktop.ScreenSaver",
     "--talk-name=org.freedesktop.PowerManagement.Inhibit",
     "--talk-name=org.freedesktop.login1",
-    "--filesystem=xdg-run/app/com.discordapp.Discord:create"
+    "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+    "--filesystem=xdg-run/gamescope-0:ro"
   ],
   "modules": [
     {


### PR DESCRIPTION
I encounter this error every time I launch a RetroArch game through Steam Deck's Game Mode UI:
![20240120_180303](https://github.com/flathub/org.DolphinEmu.dolphin-emu/assets/99134546/5a4b3ca1-99ae-41e2-9af8-6d2591799d27)

I've encountered it many times before when launching games through other Flatpaks, like those for Lutris, Heroic, and other emulators. Recently, I found that this error went away after adding support for HDR on Steam Deck to [Lutris Flatpak](https://github.com/flathub/net.lutris.Lutris/commit/3ec57b415882054d06668911aaa73761dfd47d14) -- itself based on the method used for enabling HDR support on [Heroic](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3281#issuecomment-1886180726) and [Chiaki4deck](https://github.com/streetpea/chiaki4deck/issues/93#issuecomment-1830897848).

Similar to PRs I have made for [Dolphin](https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178), [PrimeHack](https://github.com/flathub/io.github.shiiion.primehack/pull/28), and [PPSSPP](https://github.com/flathub/org.ppsspp.PPSSPP/pull/73), I have tested and confirmed that just adding the gamescope-0 socket is enough to make the error go away, with no apparent regressions, if you have the Gamescope Flatpak installed:
```bash
flatpak install flathub org.freedesktop.Platform.VulkanLayer.gamescope
```