### PR TITLE
Add gamescope Vulkan layer to enable HDR on Steam Deck OLED

### DIFF
--- a/VkLayer_FROG_gamescope_wsi.x86_64.json
+++ b/VkLayer_FROG_gamescope_wsi.x86_64.json
@@ -1,0 +1,20 @@
+{
+    "file_format_version" : "1.0.0",
+    "layer" : {
+      "name": "VK_LAYER_FROG_gamescope_wsi_x86_64",
+      "type": "GLOBAL",
+      "api_version": "1.3.221",
+      "library_path": "/var/run/host/usr/lib/libVkLayer_FROG_gamescope_wsi_x86_64.so",
+      "implementation_version": "1",
+      "description": "Gamescope WSI (XWayland Bypass) Layer (x86_64)",
+      "functions": {
+         "vkNegotiateLoaderLayerInterfaceVersion": "vkNegotiateLoaderLayerInterfaceVersion"
+      },
+      "enable_environment": {
+        "ENABLE_GAMESCOPE_WSI": "1"
+      },
+      "disable_environment": {
+        "DISABLE_GAMESCOPE_WSI": "1"
+      }
+    }
+}

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -46,6 +46,10 @@
         {
           "type": "file",
           "path": "retroarch.cfg"
+        },
+        {
+          "type": "file",
+          "path": "VkLayer_FROG_gamescope_wsi.x86_64.json"
         }
       ],
       "post-install": [
@@ -54,6 +58,8 @@
         "rmdir ${FLATPAK_DEST}/share/pixmaps/",
         "mkdir -p ${FLATPAK_DEST}/etc",
         "sed s:@prefix@:${FLATPAK_DEST}:g retroarch.cfg > ${FLATPAK_DEST}/etc/retroarch.cfg",
+        "mkdir -p ${FLATPAK_DEST}/share/vulkan/implicit_layer.d",
+        "install VkLayer_FROG_gamescope_wsi.x86_64.json /app/share/vulkan/implicit_layer.d/VkLayer_FROG_gamescope_wsi.x86_64.json",
         "mkdir -p ${FLATPAK_DEST}/share/appdata",
         "cp org.libretro.RetroArch.appdata.xml ${FLATPAK_DEST}/share/appdata"
       ],


### PR DESCRIPTION
This change enables HDR on Steam Deck OLED.
The required Vulkan colorspace and texture format is only available when Gamescope's Vulkan Layer is active.
The layer definition is not loaded from the host system, so we have to copy it into the Flatpak to make it work.

Currently RetroArch glitches when enabling HDR, but when it is restarted, HDR works as expected (confirmed with SteamOS HDR debugging view).