### PR TITLE
Update to RetroArch 1.18.0

### DIFF
--- a/org.libretro.RetroArch.appdata.xml
+++ b/org.libretro.RetroArch.appdata.xml
@@ -41,6 +41,43 @@
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="1.18.0" date="2024-03-23">
+      <description>
+      <ul>
+        <li>AI: Fix narrator language when AI translation and menu languages are different</li>
+        <li>DISK CONTROL: Add option to disable initial disk change</li>
+        <li>DISK CONTROL: Visibility option for disk control notifications</li>
+        <li>DRM: Fix mode vrefresh calculation. When using an interlaced/doublescan mode, the vertical refresh rate is mis-calculated.</li>
+        <li>INPUT: Fix input state combos including R3 and false triggers of RETROK_UNKNOWN</li>
+        <li>INPUT: Add a new turbo mode, "Classic (Toggle)"</li>
+        <li>INPUT: Fix bind hold when axis does not rest at 0</li>
+        <li>INPUT: Limit axis threshold setting to sensible values</li>
+        <li>INPUT: Add Overlay Mouse, Lightgun, and Pointer</li>
+        <li>INPUT/LINUXRAW: Fix device name and hotplug reconnect</li>
+        <li>LIBRETRO: Add Doxygen-styled comments to parts of the libretro API</li>
+        <li>LUA: Update Lua to version 5.3.6</li>
+        <li>MENU: Add sublabels for input bind common entries</li>
+        <li>MENU: Don't load history and favorites if size is 0</li>
+        <li>MENU: Don't disable fast forward when entering menu</li>
+        <li>MENU: Widget position, size, color, icon adjustments</li>
+        <li>MENU: Fix savestate slots in Qt UI</li>
+        <li>MENU: Reorder and reduce depth of User Interface menu</li>
+        <li>MENU/OZONE: Fix sidebar wraparound, visibility after config load, crash after playlist delete</li>
+        <li>MENU/OZONE: Fix sidebar and sublabel animations</li>
+        <li>REMOTE RETROPAD: add display for analog axes, indication of inputs already pressed</li>
+        <li>SAVES: Allow combining saves in content dir with save sorting</li>
+        <li>SHADER: Added rolling scan line simulation based on the shader subframe feature. This is implemented with a scrolling scissor rect rather than in the shader itself as this is more efficient although may not work for every shader pass - we may need an option to exclude certain passes. The implementation simply divides the screen up by the number of sub frames and then moves the scissor rect down over the screen over the number of sub frames</li>
+        <li>UWP: Enable HAVE_ACCESSIBILITY for UWP builds</li>
+        <li>UWP: Allow UWP build to work with a modified version of Mesa Gallium D3D12</li>
+        <li>VIDEO: Add subframe shader support for Vulkan/GLcore/DX10-11-12, enabling shaders to run at higher framerate than the content</li>
+        <li>VIDEO: Fix restoring fullscreen/windowed setting when unloading override</li>
+        <li>VIDEO/VULKAN: Fix HDR with Vulkan after reinit</li>
+        <li>VIDEO/VULKAN: Remove the use of oldSwapchain</li>
+        <li>VIDEO/GL2: Fix OpenGL ES version detection</li>
+        <li>WEBDAV: Fixed SEGFAULT in WebDav task sync + type changes</li>
+      </ul>
+      </description>
+    </release>
     <release version="1.17.0" date="2024-02-03">
       <description>
         <ul>

--- a/org.libretro.RetroArch.appdata.xml
+++ b/org.libretro.RetroArch.appdata.xml
@@ -47,7 +47,7 @@
         <li>AI: Fix narrator language when AI translation and menu languages are different</li>
         <li>DISK CONTROL: Add option to disable initial disk change</li>
         <li>DISK CONTROL: Visibility option for disk control notifications</li>
-        <li>DRM: Fix mode vrefresh calculation. When using an interlaced/doublescan mode, the vertical refresh rate is mis-calculated.</li>
+        <li>DRM: Fix mode vrefresh calculation</li>
         <li>INPUT: Fix input state combos including R3 and false triggers of RETROK_UNKNOWN</li>
         <li>INPUT: Add a new turbo mode, "Classic (Toggle)"</li>
         <li>INPUT: Fix bind hold when axis does not rest at 0</li>
@@ -66,10 +66,10 @@
         <li>MENU/OZONE: Fix sidebar and sublabel animations</li>
         <li>REMOTE RETROPAD: add display for analog axes, indication of inputs already pressed</li>
         <li>SAVES: Allow combining saves in content dir with save sorting</li>
-        <li>SHADER: Added rolling scan line simulation based on the shader subframe feature. This is implemented with a scrolling scissor rect rather than in the shader itself as this is more efficient although may not work for every shader pass - we may need an option to exclude certain passes. The implementation simply divides the screen up by the number of sub frames and then moves the scissor rect down over the screen over the number of sub frames</li>
+        <li>SHADER: Added rolling scan line simulation based on the shader subframe feature</li>
         <li>UWP: Enable HAVE_ACCESSIBILITY for UWP builds</li>
         <li>UWP: Allow UWP build to work with a modified version of Mesa Gallium D3D12</li>
-        <li>VIDEO: Add subframe shader support for Vulkan/GLcore/DX10-11-12, enabling shaders to run at higher framerate than the content</li>
+        <li>VIDEO: Add subframe shader support for Vulkan/GLcore, enabling shaders to run at higher framerate than the content</li>
         <li>VIDEO: Fix restoring fullscreen/windowed setting when unloading override</li>
         <li>VIDEO/VULKAN: Fix HDR with Vulkan after reinit</li>
         <li>VIDEO/VULKAN: Remove the use of oldSwapchain</li>

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -37,7 +37,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/RetroArch.git",
-          "commit": "ad8975cb5a0fe45be43438bdbd6c3d745653dd02"
+          "commit": "06fa5325f8b3cd42e6fba3d57835d5924c9ea2e7"
         },
         {
           "type": "file",
@@ -91,7 +91,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/RetroArch.git",
-          "commit": "ad8975cb5a0fe45be43438bdbd6c3d745653dd02"
+          "commit": "06fa5325f8b3cd42e6fba3d57835d5924c9ea2e7"
         }
       ]
     },
@@ -105,7 +105,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/RetroArch.git",
-          "commit": "ad8975cb5a0fe45be43438bdbd6c3d745653dd02"
+          "commit": "06fa5325f8b3cd42e6fba3d57835d5924c9ea2e7"
         }
       ]
     },
@@ -131,7 +131,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/libretro-database.git",
-          "commit": "2c121df3a1c661e7a686f159ec5500a2837eefb3"
+          "commit": "977612e2cd284f67fc0d121d9d94c5982a49f61e"
         }
       ]
     },
@@ -144,7 +144,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/libretro-core-info.git",
-          "commit": "ef6815722bfd4cc7d0cf14640b7111ecb5709cdd"
+          "commit": "ad0f67e172dca9edb88a4eea1d541f407a9c2d12"
         }
       ]
     },
@@ -157,7 +157,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/retroarch-joypad-autoconfig.git",
-          "commit": "9999374439b6526cfec78dd1fc51ed889e51ec6d"
+          "commit": "ec43cfef730f15d6b20bf277681250b2f4b99a8b"
         }
       ]
     },
@@ -183,7 +183,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/slang-shaders.git",
-          "commit": "5b4c9b2a75aba5f57fcb5b68662a06f0ed7c929f"
+          "commit": "d367f6cf73e01a8e43028107ab1ded2d2f05fe6a"
         }
       ]
     },
@@ -196,7 +196,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/glsl-shaders.git",
-          "commit": "bc8df92f013a128c3a735a57d3d98c6f087cc291"
+          "commit": "db974e4d6f6e3178198b7690095a107b3b509d4b"
         }
       ]
     },
@@ -209,7 +209,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/common-overlays.git",
-          "commit": "115d8670c2e032e4a41ba45f766f5cfd9dae28b8"
+          "commit": "c266abf4d7f9286fb6fbcfb57647cd9c80c45530"
         }
       ]
     }


### PR DESCRIPTION
*   AI: Fix narrator language when AI translation and menu languages are different
*   DISK CONTROL: Add option to disable initial disk change
*   DISK CONTROL: Visibility option for disk control notifications
*   DRM: Fix mode vrefresh calculation. When using an interlaced/doublescan mode, the vertical refresh rate is mis-calculated.
*   INPUT: Fix input state combos including R3 and false triggers of RETROK\_UNKNOWN
*   INPUT: Add a new turbo mode, "Classic (Toggle)"
*   INPUT: Fix bind hold when axis does not rest at 0
*   INPUT: Limit axis threshold setting to sensible values
*   INPUT: Add Overlay Mouse, Lightgun, and Pointer
*   INPUT/LINUXRAW: Fix device name and hotplug reconnect
*   LIBRETRO: Add Doxygen-styled comments to parts of the libretro API
*   LUA: Update Lua to version 5.3.6
*   MENU: Add sublabels for input bind common entries
*   MENU: Don't load history and favorites if size is 0
*   MENU: Don't disable fast forward when entering menu
*   MENU: Widget position, size, color, icon adjustments
*   MENU: Fix savestate slots in Qt UI
*   MENU: Reorder and reduce depth of User Interface menu
*   MENU/OZONE: Fix sidebar wraparound, visibility after config load, crash after playlist delete
*   MENU/OZONE: Fix sidebar and sublabel animations
*   REMOTE RETROPAD: add display for analog axes, indication of inputs already pressed
*   SAVES: Allow combining saves in content dir with save sorting
*   SHADER: Added rolling scan line simulation based on the shader subframe feature. This is implemented with a scrolling scissor rect rather than in the shader itself as this is more efficient although may not work for every shader pass - we may need an option to exclude certain passes. The implementation simply divides the screen up by the number of sub frames and then moves the scissor rect down over the screen over the number of sub frames
*   UWP: Enable HAVE\_ACCESSIBILITY for UWP builds
*   UWP: Allow UWP build to work with a modified version of Mesa Gallium D3D12
*   VIDEO: Add subframe shader support for Vulkan/GLcore/DX10-11-12, enabling shaders to run at higher framerate than the content
*   VIDEO: Fix restoring fullscreen/windowed setting when unloading override
*   VIDEO/VULKAN: Fix HDR with Vulkan after reinit
*   VIDEO/VULKAN: Remove the use of oldSwapchain
*   VIDEO/GL2: Fix OpenGL ES version detection
*   WEBDAV: Fixed SEGFAULT in WebDav task sync + type changes

Fixes #286