### PR TITLE
Add pcaudiolib

### DIFF
--- a/modules/pcaudiolib/pcaudiolib-1.2.json
+++ b/modules/pcaudiolib/pcaudiolib-1.2.json
@@ -1,0 +1,16 @@
+{
+    "name": "pcaudiolib",
+    "cleanup": [ "*.la" ],
+    "no-parallel-make": true,
+    "build-options": {
+        "ldflags": "-Wl,--allow-multiple-definition"
+    },
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/espeak-ng/pcaudiolib.git",
+            "tag": "1.2",
+            "commit": "a406af5e57642d671224b32b8135d6cc30b52609"
+        }
+    ]
+}

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -80,6 +80,7 @@
         "shared-modules/glu/glu-9.json",
         "modules/libdecor/libdecor.json",
         "modules/gamemode/gamemode-1.8.json",
+        "modules/pcaudiolib/pcaudiolib-1.2.json",
         "modules/espeak-ng/espeak-ng-1.51.1.json"
       ]
     },


### PR DESCRIPTION
Add main dependency for `espeak-ng` . This library must be built before espeak, as it is needed both for building and runtime.