### PR TITLE
Update libretro-database to fix (even shorter) file name length

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -134,7 +134,7 @@
         {
           "type": "git",
           "url": "https://github.com/libretro/libretro-database.git",
-          "commit": "10b3e4fbe7562c10c4de878ee1ffa0175b0af409"
+          "commit": "e46696207f55fdc808f9bf2ae03568ca96e36c1f"
         }
       ]
     },


### PR DESCRIPTION
Update to the latest version of libretro-database to fix an issue with long filenames.

See [this PR to libretro-database](https://github.com/libretro/libretro-database/pull/1484#event-14092515727)

Related to #300 