### PR TITLE
Add missing "xdg-run/discord-ipc-0:create" permission.

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -21,6 +21,7 @@
     "--talk-name=org.freedesktop.PowerManagement.Inhibit",
     "--talk-name=org.freedesktop.login1",
     "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+    "--filesystem=xdg-run/discord-ipc-0:create",
     "--filesystem=xdg-run/gamescope-0:ro"
   ],
   "modules": [


### PR DESCRIPTION
This fixes rich presence not working with the official Discord install.