### PR TITLE
libdecor: disable GTK plugin to fix startup busy cursor

### DIFF
--- a/modules/libdecor/libdecor.json
+++ b/modules/libdecor/libdecor.json
@@ -3,7 +3,8 @@
   "buildsystem": "meson",
   "config-opts": [
     "-Ddemo=false",
-    "-Dgtk=disabled"
+    "-Dgtk=disabled",
+    "-Dgtk+3=disabled"
   ],
   "sources": [
     {

--- a/modules/libdecor/libdecor.json
+++ b/modules/libdecor/libdecor.json
@@ -2,7 +2,8 @@
   "name": "libdecor",
   "buildsystem": "meson",
   "config-opts": [
-    "-Ddemo=false"
+    "-Ddemo=false",
+    "-Dgtk=disabled"
   ],
   "sources": [
     {

--- a/modules/libdecor/libdecor.json
+++ b/modules/libdecor/libdecor.json
@@ -3,8 +3,7 @@
   "buildsystem": "meson",
   "config-opts": [
     "-Ddemo=false",
-    "-Dgtk=disabled",
-    "-Dgtk+3=disabled"
+    "-Dgtk=disabled"
   ],
   "sources": [
     {


### PR DESCRIPTION
Disables the GTK decoration plugin when building libdecor by adding `-Dgtk=disabled` to the meson config.

The KDE Flatpak runtime does not include GTK, so libdecor was trying to load its GTK plugin at startup, timing out after 10-20 seconds, and causing a busy cursor on GNOME Wayland (Fedora). Using the built-in fallback CSD plugin avoids this delay entirely.

Fixes #347