### PR TITLE
Restrict nvidia-cg-toolkit to x86_64

### DIFF
--- a/modules/nvidia-cg-toolkit/nvidia-cg-toolkit-3.1.0013.json
+++ b/modules/nvidia-cg-toolkit/nvidia-cg-toolkit-3.1.0013.json
@@ -1,5 +1,8 @@
 {
   "name": "nvidia-cg-toolkit",
+  "only-arches": [
+    "x86_64"
+  ],
   "buildsystem": "simple",
   "build-commands": [
     "mkdir -p ${FLATPAK_DEST}/lib",


### PR DESCRIPTION
The Cg toolkit is an x86_64-only binary archive, so skip it on other architectures instead of shipping non-functional libraries.