### PR TITLE
Install gamescope WSI layer only on x86_64

### DIFF
--- a/modules/gamescope/gamescope-wsi-layer.json
+++ b/modules/gamescope/gamescope-wsi-layer.json
@@ -1,0 +1,16 @@
+{
+  "name": "gamescope-wsi-layer",
+  "only-arches": [
+    "x86_64"
+  ],
+  "buildsystem": "simple",
+  "build-commands": [
+    "install -Dm644 VkLayer_FROG_gamescope_wsi.x86_64.json ${FLATPAK_DEST}/share/vulkan/implicit_layer.d/VkLayer_FROG_gamescope_wsi.x86_64.json"
+  ],
+  "sources": [
+    {
+      "type": "file",
+      "path": "VkLayer_FROG_gamescope_wsi.x86_64.json"
+    }
+  ]
+}

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -50,11 +50,6 @@
         {
           "type": "file",
           "path": "retroarch.cfg"
-        },
-        {
-          "type": "file",
-          "path": "modules/gamescope/VkLayer_FROG_gamescope_wsi.x86_64.json",
-          "dest": "modules/gamescope"
         }
       ],
       "post-install": [
@@ -63,8 +58,6 @@
         "rmdir ${FLATPAK_DEST}/share/pixmaps/",
         "mkdir -p ${FLATPAK_DEST}/etc",
         "sed s:@prefix@:${FLATPAK_DEST}:g retroarch.cfg > ${FLATPAK_DEST}/etc/retroarch.cfg",
-        "mkdir -p ${FLATPAK_DEST}/share/vulkan/implicit_layer.d",
-        "install modules/gamescope/VkLayer_FROG_gamescope_wsi.x86_64.json ${FLATPAK_DEST}/share/vulkan/implicit_layer.d/VkLayer_FROG_gamescope_wsi.x86_64.json",
         "mkdir -p ${FLATPAK_DEST}/share/metainfo",
         "cp org.libretro.RetroArch.metainfo.xml ${FLATPAK_DEST}/share/metainfo"
       ],
@@ -74,7 +67,8 @@
         "shared-modules/glu/glu-9.json",
         "modules/libdecor/libdecor.json",
         "modules/pcaudiolib/pcaudiolib-1.3.json",
-        "modules/espeak-ng/espeak-ng-1.52.json"
+        "modules/espeak-ng/espeak-ng-1.52.json",
+        "modules/gamescope/gamescope-wsi-layer.json"
       ]
     },
     {


### PR DESCRIPTION
The layer JSON points at an x86_64-only host library, so move its install into an x86_64-only module instead of shipping it on aarch64.