### PR TITLE
Restrict Cg shaders to x86_64, fetch over HTTPS

### DIFF
--- a/modules/nvidia-cg-toolkit/nvidia-cg-toolkit-3.1.0013.json
+++ b/modules/nvidia-cg-toolkit/nvidia-cg-toolkit-3.1.0013.json
@@ -12,7 +12,7 @@
   "sources": [
     {
       "type": "archive",
-      "url": "http://developer.download.nvidia.com/cg/Cg_3.1/Cg-3.1_April2012_x86_64.tgz",
+      "url": "https://developer.download.nvidia.com/cg/Cg_3.1/Cg-3.1_April2012_x86_64.tgz",
       "sha256": "e8ff01e6cc38d1b3fd56a083f5860737dbd2f319a39037528fb1a74a89ae9878"
     }
   ]

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -159,6 +159,9 @@
     },
     {
       "name": "common-shaders",
+      "only-arches": [
+        "x86_64"
+      ],
       "make-install-args": [
         "PREFIX=${FLATPAK_DEST}"
       ],


### PR DESCRIPTION
Cg shaders are unusable on aarch64 since libCg is x86_64-only, and the toolkit download now uses HTTPS.