### PR TITLE
Make host filesystem access read-only

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -13,7 +13,7 @@
     "--share=ipc",
     "--share=network",
     "--device=all",
-    "--filesystem=host",
+    "--filesystem=host:ro",
     "--filesystem=/run/udev:ro",
     "--filesystem=xdg-run/pipewire-0",
     "--allow=multiarch",


### PR DESCRIPTION
Saves, states, configs, and screenshots default to the app data dir, so ROM access only needs read; users with custom directories outside the sandbox can grant write with a filesystem override. Addresses #308.