### PR TITLE
Fix filter module name typos

### DIFF
--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "name": "retroarch-filers-video",
+      "name": "retroarch-filters-video",
       "subdir": "gfx/video_filters",
       "make-install-args": [
         "PREFIX=${FLATPAK_DEST}"
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "name": "retroarch-filers-audio",
+      "name": "retroarch-filters-audio",
       "subdir": "libretro-common/audio/dsp_filters",
       "make-install-args": [
         "PREFIX=${FLATPAK_DEST}"


### PR DESCRIPTION
Renames the retroarch-filers-* modules to retroarch-filters-*.